### PR TITLE
simplify imports / make duckdb default for wrap_openai

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ We differentiate between observers and stores. Observers wrap generative AI APIs
 To get started you can run the code below. It sends requests to a HF serverless endpoint and log the interactions into a Hub dataset, using the default store `DatasetsStore`. The dataset will be pushed to your personal workspace (http://hf.co/{your_username}). To learn how to configure stores, go to the next section.
 
 ```python
-from observers.observers.models.openai import wrap_openai
-from observers.stores.duckdb import DuckDBStore
+from observers.observers import wrap_openai
+from observers.stores import DuckDBStore
 from openai import OpenAI
 
 store = DuckDBStore()

--- a/examples/argilla_example.py
+++ b/examples/argilla_example.py
@@ -1,5 +1,5 @@
-from observers.observers.models.openai import wrap_openai
-from observers.stores.argilla import ArgillaStore
+from observers.observers import wrap_openai
+from observers.stores import ArgillaStore
 from openai import OpenAI
 
 api_url = "<argilla-api-url>"

--- a/examples/datasets_example.py
+++ b/examples/datasets_example.py
@@ -1,5 +1,5 @@
-from observers.observers.models.openai import wrap_openai
-from observers.stores.datasets import DatasetsStore
+from observers.observers import wrap_openai
+from observers.stores import DatasetsStore
 from openai import OpenAI
 
 store = DatasetsStore(

--- a/examples/datasets_example.py
+++ b/examples/datasets_example.py
@@ -4,7 +4,7 @@ from openai import OpenAI
 
 store = DatasetsStore(
     repo_name="gpt-4o-traces",
-    every=5,  # sync every 5 messages
+    every=5,  # sync every 5 minutes
 )
 
 openai_client = OpenAI()

--- a/examples/duckdb_example.py
+++ b/examples/duckdb_example.py
@@ -1,5 +1,5 @@
-from observers.observers.models.openai import wrap_openai
-from observers.stores.duckdb import DuckDBStore
+from observers.observers import wrap_openai
+from observers.stores import DuckDBStore
 from openai import OpenAI
 
 store = DuckDBStore()

--- a/examples/hf_inference_example.py
+++ b/examples/hf_inference_example.py
@@ -6,7 +6,7 @@ from openai import OpenAI
 
 store = DatasetsStore(
     repo_name="qwen-2-5-traces",
-    every=5,  # sync every 5 messages
+    every=5,  # sync every 5 minutes
     private=True,  # make the repo private
 )
 

--- a/examples/hf_inference_example.py
+++ b/examples/hf_inference_example.py
@@ -1,7 +1,7 @@
 import os
 
-from observers.observers.models.openai import wrap_openai
-from observers.stores.datasets import DatasetsStore
+from observers.observers import wrap_openai
+from observers.stores import DatasetsStore
 from openai import OpenAI
 
 store = DatasetsStore(

--- a/examples/ollama_example.py
+++ b/examples/ollama_example.py
@@ -1,5 +1,5 @@
-from observers.observers.models.openai import wrap_openai
-from observers.stores.duckdb import DuckDBStore
+from observers.observers import wrap_openai
+from observers.stores import DuckDBStore
 from openai import OpenAI
 
 store = DuckDBStore()

--- a/examples/openai_function_calling_example.py
+++ b/examples/openai_function_calling_example.py
@@ -4,7 +4,7 @@ from openai import OpenAI
 
 store = DatasetsStore(
     repo_name="gpt-4o-function-calling-traces",
-    every=5,  # sync every 5 messages
+    every=5,  # sync every 5 minutes
 )
 
 openai_client = OpenAI()

--- a/examples/openai_function_calling_example.py
+++ b/examples/openai_function_calling_example.py
@@ -1,5 +1,5 @@
-from observers.observers.models.openai import wrap_openai
-from observers.stores.datasets import DatasetsStore
+from observers.observers import wrap_openai
+from observers.stores import DatasetsStore
 from openai import OpenAI
 
 store = DatasetsStore(

--- a/examples/vision_example.py
+++ b/examples/vision_example.py
@@ -1,5 +1,5 @@
-from observers.observers.models.openai import wrap_openai
-from observers.stores.datasets import DatasetsStore
+from observers.observers import wrap_openai
+from observers.stores import DatasetsStore
 from openai import OpenAI
 
 store = DatasetsStore(

--- a/src/observers/observers/__init__.py
+++ b/src/observers/observers/__init__.py
@@ -1,0 +1,3 @@
+from observers.observers.models.openai import wrap_openai
+
+__all__ = ["wrap_openai"]

--- a/src/observers/observers/models/openai.py
+++ b/src/observers/observers/models/openai.py
@@ -4,12 +4,12 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from observers.observers.base import Message, Record
-from observers.stores.datasets import DatasetsStore
+from observers.stores.duckdb import DuckDBStore
 from openai import OpenAI
 
 if TYPE_CHECKING:
     from argilla import Argilla
-    from observers.stores.duckdb import DuckDBStore
+    from observers.stores.datasets import DatasetsStore
 
 
 @dataclass
@@ -164,7 +164,7 @@ class OpenAIResponseRecord(Record):
 
 def wrap_openai(
     client: OpenAI,
-    store: Optional[Union["DuckDBStore", DatasetsStore]] = None,
+    store: Optional[Union[ "DatasetsStore", DuckDBStore]] = None,
     tags: Optional[List[str]] = None,
     properties: Optional[Dict[str, Any]] = None,
 ) -> OpenAI:
@@ -178,7 +178,7 @@ def wrap_openai(
         properties: Optional dictionary of properties to associate with records
     """
     if store is None:
-        store = DatasetsStore.connect()
+        store = DuckDBStore.connect()
 
     original_create = client.chat.completions.create
 

--- a/src/observers/stores/__init__.py
+++ b/src/observers/stores/__init__.py
@@ -1,1 +1,5 @@
+from observers.stores.argilla import ArgillaStore
+from observers.stores.datasets import DatasetsStore
+from observers.stores.duckdb import DuckDBStore
 
+__all__ = ["ArgillaStore", "DatasetsStore", "DuckDBStore"]


### PR DESCRIPTION
This should simplify and make the imports more findable / understandable. Other change is making `DuckDB` default for `wrap_openai` so there isn't a remote dependency.

## Before

```python
from observers.observers.models.openai import wrap_openai
from observers.stores.duckdb import DuckDBStore
from observers.stores.datasets import DatasetsStore
```
## After

```python
from observers.observers import wrap_openai
from observers.stores import DuckDBStore
from observers.stores import DatasetsStore
```