### PR TITLE
use temp / isolated directory for DatasetStore

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,0 +1,10 @@
+name: Lint
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: psf/black@stable

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -1,0 +1,23 @@
+name: Python Tests
+
+on: [push, pull_request]
+
+jobs:
+  build_and_test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ "3.10", "3.11", "3.12" ]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pdm
+          pdm install
+      - name: Test with pytest
+        run: pdm run pytest

--- a/examples/datasets_example.py
+++ b/examples/datasets_example.py
@@ -4,7 +4,7 @@ from openai import OpenAI
 
 store = DatasetsStore(
     repo_name="gpt-4o-traces",
-    every=5,  # sync every 5 messages
+    every=5,  # sync every 5 minutes
 )
 
 openai_client = OpenAI()

--- a/examples/openai_function_calling_example.py
+++ b/examples/openai_function_calling_example.py
@@ -26,19 +26,19 @@ tools = [
                 "required": ["order_id"],
                 "additionalProperties": False,
             },
-        }
+        },
     }
 ]
 
 messages = [
     {
         "role": "system",
-        "content": "You are a helpful customer support assistant. Use the supplied tools to assist the user."
+        "content": "You are a helpful customer support assistant. Use the supplied tools to assist the user.",
     },
     {
         "role": "user",
-        "content": "Hi, can you tell me the delivery date for my order? It's order 1234567890."
-    }
+        "content": "Hi, can you tell me the delivery date for my order? It's order 1234567890.",
+    },
 ]
 
 

--- a/examples/vision_example.py
+++ b/examples/vision_example.py
@@ -11,22 +11,22 @@ openai_client = OpenAI()
 client = wrap_openai(openai_client, store=store)
 
 response = client.chat.completions.create(
-  model="gpt-4o-mini",
-  messages=[
-    {
-      "role": "user",
-      "content": [
-        {"type": "text", "text": "What’s in this image?"},
+    model="gpt-4o-mini",
+    messages=[
         {
-          "type": "image_url",
-          "image_url": {
-            "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg",
-          },
-        },
-      ],
-    }
-  ],
-  max_tokens=300,
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "What’s in this image?"},
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg",
+                    },
+                },
+            ],
+        }
+    ],
+    max_tokens=300,
 )
 
 print(response.choices[0].message.content)

--- a/pdm.lock
+++ b/pdm.lock
@@ -2,10 +2,10 @@
 # It is not intended for manual editing.
 
 [metadata]
-groups = ["default"]
+groups = ["default", "test"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:624542caf3a4050c2e30cf371b18e286c1b724469a149bcfc9d4255edb493c20"
+content_hash = "sha256:d4d6925c986f0448f20d2ee82a9cd1dab9cfc644b5af1c738946978e45f436d4"
 
 [[metadata.targets]]
 requires_python = ">=3.10,<3.13"
@@ -264,8 +264,8 @@ name = "colorama"
 version = "0.4.6"
 requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 summary = "Cross-platform colored terminal text."
-groups = ["default"]
-marker = "platform_system == \"Windows\""
+groups = ["default", "test"]
+marker = "sys_platform == \"win32\" or platform_system == \"Windows\""
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
@@ -359,7 +359,7 @@ name = "exceptiongroup"
 version = "1.2.2"
 requires_python = ">=3.7"
 summary = "Backport of PEP 654 (exception groups)"
-groups = ["default"]
+groups = ["default", "test"]
 marker = "python_version < \"3.11\""
 files = [
     {file = "exceptiongroup-1.2.2-py3-none-any.whl", hash = "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b"},
@@ -551,6 +551,17 @@ dependencies = [
 files = [
     {file = "importlib_metadata-8.5.0-py3-none-any.whl", hash = "sha256:45e54197d28b7a7f1559e60b95e7c567032b602131fbd588f1497f47880aa68b"},
     {file = "importlib_metadata-8.5.0.tar.gz", hash = "sha256:71522656f0abace1d072b9e5481a48f07c138e00f079c38c8f883823f9c26bd7"},
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.0.0"
+requires_python = ">=3.7"
+summary = "brain-dead simple config-ini parsing"
+groups = ["test"]
+files = [
+    {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
+    {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
 ]
 
 [[package]]
@@ -883,7 +894,7 @@ name = "packaging"
 version = "24.2"
 requires_python = ">=3.8"
 summary = "Core utilities for Python packages"
-groups = ["default"]
+groups = ["default", "test"]
 files = [
     {file = "packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759"},
     {file = "packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f"},
@@ -976,6 +987,17 @@ files = [
     {file = "pillow-11.0.0-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:e58876c91f97b0952eb766123bfef372792ab3f4e3e1f1a2267834c2ab131734"},
     {file = "pillow-11.0.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:224aaa38177597bb179f3ec87eeefcce8e4f85e608025e9cfac60de237ba6316"},
     {file = "pillow-11.0.0.tar.gz", hash = "sha256:72bacbaf24ac003fea9bff9837d1eedb6088758d41e100c1552930151f677739"},
+]
+
+[[package]]
+name = "pluggy"
+version = "1.5.0"
+requires_python = ">=3.8"
+summary = "plugin and hook calling mechanisms for python"
+groups = ["test"]
+files = [
+    {file = "pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669"},
+    {file = "pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1"},
 ]
 
 [[package]]
@@ -1156,6 +1178,25 @@ groups = ["default"]
 files = [
     {file = "pygments-2.18.0-py3-none-any.whl", hash = "sha256:b8e6aca0523f3ab76fee51799c488e38782ac06eafcf95e7ba832985c8e7b13a"},
     {file = "pygments-2.18.0.tar.gz", hash = "sha256:786ff802f32e91311bff3889f6e9a86e81505fe99f2735bb6d60ae0c5004f199"},
+]
+
+[[package]]
+name = "pytest"
+version = "8.3.3"
+requires_python = ">=3.8"
+summary = "pytest: simple powerful testing with Python"
+groups = ["test"]
+dependencies = [
+    "colorama; sys_platform == \"win32\"",
+    "exceptiongroup>=1.0.0rc8; python_version < \"3.11\"",
+    "iniconfig",
+    "packaging",
+    "pluggy<2,>=1.5",
+    "tomli>=1; python_version < \"3.11\"",
+]
+files = [
+    {file = "pytest-8.3.3-py3-none-any.whl", hash = "sha256:a6853c7375b2663155079443d2e45de913a911a11d669df02a50814944db57b2"},
+    {file = "pytest-8.3.3.tar.gz", hash = "sha256:70b98107bd648308a7952b06e6ca9a50bc660be218d53c257cc1fc94fda10181"},
 ]
 
 [[package]]
@@ -1503,6 +1544,18 @@ files = [
     {file = "tokenizers-0.20.3-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:55046ad3dd5f2b3c67501fcc8c9cbe3e901d8355f08a3b745e9b57894855f85b"},
     {file = "tokenizers-0.20.3-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:efcf0eb939988b627558aaf2b9dc3e56d759cad2e0cfa04fcab378e4b48fc4fd"},
     {file = "tokenizers-0.20.3.tar.gz", hash = "sha256:2278b34c5d0dd78e087e1ca7f9b1dcbf129d80211afa645f214bd6e051037539"},
+]
+
+[[package]]
+name = "tomli"
+version = "2.1.0"
+requires_python = ">=3.8"
+summary = "A lil' TOML parser"
+groups = ["test"]
+marker = "python_version < \"3.11\""
+files = [
+    {file = "tomli-2.1.0-py3-none-any.whl", hash = "sha256:a5c57c3d1c56f5ccdf89f6523458f60ef716e210fc47c4cfb188c5ba473e0391"},
+    {file = "tomli-2.1.0.tar.gz", hash = "sha256:3f646cae2aec94e17d04973e4249548320197cfabdf130015d023de4b74d8ab8"},
 ]
 
 [[package]]

--- a/pdm.lock
+++ b/pdm.lock
@@ -2,10 +2,10 @@
 # It is not intended for manual editing.
 
 [metadata]
-groups = ["default", "test"]
+groups = ["default", "lint", "test"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:d4d6925c986f0448f20d2ee82a9cd1dab9cfc644b5af1c738946978e45f436d4"
+content_hash = "sha256:b7aebf68c66ff31e2cf54cc299900c2c36b3c897631ab2a49a49f418c689ecad"
 
 [[metadata.targets]]
 requires_python = ">=3.10,<3.13"
@@ -178,6 +178,38 @@ files = [
 ]
 
 [[package]]
+name = "black"
+version = "24.10.0"
+requires_python = ">=3.9"
+summary = "The uncompromising code formatter."
+groups = ["lint"]
+dependencies = [
+    "click>=8.0.0",
+    "mypy-extensions>=0.4.3",
+    "packaging>=22.0",
+    "pathspec>=0.9.0",
+    "platformdirs>=2",
+    "tomli>=1.1.0; python_version < \"3.11\"",
+    "typing-extensions>=4.0.1; python_version < \"3.11\"",
+]
+files = [
+    {file = "black-24.10.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e6668650ea4b685440857138e5fe40cde4d652633b1bdffc62933d0db4ed9812"},
+    {file = "black-24.10.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1c536fcf674217e87b8cc3657b81809d3c085d7bf3ef262ead700da345bfa6ea"},
+    {file = "black-24.10.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:649fff99a20bd06c6f727d2a27f401331dc0cc861fb69cde910fe95b01b5928f"},
+    {file = "black-24.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:fe4d6476887de70546212c99ac9bd803d90b42fc4767f058a0baa895013fbb3e"},
+    {file = "black-24.10.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5a2221696a8224e335c28816a9d331a6c2ae15a2ee34ec857dcf3e45dbfa99ad"},
+    {file = "black-24.10.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f9da3333530dbcecc1be13e69c250ed8dfa67f43c4005fb537bb426e19200d50"},
+    {file = "black-24.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4007b1393d902b48b36958a216c20c4482f601569d19ed1df294a496eb366392"},
+    {file = "black-24.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:394d4ddc64782e51153eadcaaca95144ac4c35e27ef9b0a42e121ae7e57a9175"},
+    {file = "black-24.10.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b5e39e0fae001df40f95bd8cc36b9165c5e2ea88900167bddf258bacef9bbdc3"},
+    {file = "black-24.10.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d37d422772111794b26757c5b55a3eade028aa3fde43121ab7b673d050949d65"},
+    {file = "black-24.10.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14b3502784f09ce2443830e3133dacf2c0110d45191ed470ecb04d0f5f6fcb0f"},
+    {file = "black-24.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:30d2c30dc5139211dda799758559d1b049f7f14c580c409d6ad925b74a4208a8"},
+    {file = "black-24.10.0-py3-none-any.whl", hash = "sha256:3bb2b7a1f7b685f85b11fed1ef10f8a9148bceb49853e47a294a3dd963c1dd7d"},
+    {file = "black-24.10.0.tar.gz", hash = "sha256:846ea64c97afe3bc677b761787993be4991810ecc7a4a937816dd6bddedc4875"},
+]
+
+[[package]]
 name = "certifi"
 version = "2024.8.30"
 requires_python = ">=3.6"
@@ -249,7 +281,7 @@ name = "click"
 version = "8.1.7"
 requires_python = ">=3.7"
 summary = "Composable command line interface toolkit"
-groups = ["default"]
+groups = ["default", "lint"]
 dependencies = [
     "colorama; platform_system == \"Windows\"",
     "importlib-metadata; python_version < \"3.8\"",
@@ -264,7 +296,7 @@ name = "colorama"
 version = "0.4.6"
 requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 summary = "Cross-platform colored terminal text."
-groups = ["default", "test"]
+groups = ["default", "lint", "test"]
 marker = "sys_platform == \"win32\" or platform_system == \"Windows\""
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
@@ -824,6 +856,17 @@ files = [
 ]
 
 [[package]]
+name = "mypy-extensions"
+version = "1.0.0"
+requires_python = ">=3.5"
+summary = "Type system extensions for programs checked with the mypy type checker."
+groups = ["lint"]
+files = [
+    {file = "mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d"},
+    {file = "mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"},
+]
+
+[[package]]
 name = "numpy"
 version = "2.1.3"
 requires_python = ">=3.10"
@@ -894,7 +937,7 @@ name = "packaging"
 version = "24.2"
 requires_python = ">=3.8"
 summary = "Core utilities for Python packages"
-groups = ["default", "test"]
+groups = ["default", "lint", "test"]
 files = [
     {file = "packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759"},
     {file = "packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f"},
@@ -937,6 +980,17 @@ files = [
     {file = "pandas-2.2.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:062309c1b9ea12a50e8ce661145c6aab431b1e99530d3cd60640e255778bd43a"},
     {file = "pandas-2.2.3-cp312-cp312-win_amd64.whl", hash = "sha256:59ef3764d0fe818125a5097d2ae867ca3fa64df032331b7e0917cf5d7bf66b13"},
     {file = "pandas-2.2.3.tar.gz", hash = "sha256:4f18ba62b61d7e192368b84517265a99b4d7ee8912f8708660fb4a366cc82667"},
+]
+
+[[package]]
+name = "pathspec"
+version = "0.12.1"
+requires_python = ">=3.8"
+summary = "Utility library for gitignore style pattern matching of file paths."
+groups = ["lint"]
+files = [
+    {file = "pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08"},
+    {file = "pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712"},
 ]
 
 [[package]]
@@ -987,6 +1041,17 @@ files = [
     {file = "pillow-11.0.0-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:e58876c91f97b0952eb766123bfef372792ab3f4e3e1f1a2267834c2ab131734"},
     {file = "pillow-11.0.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:224aaa38177597bb179f3ec87eeefcce8e4f85e608025e9cfac60de237ba6316"},
     {file = "pillow-11.0.0.tar.gz", hash = "sha256:72bacbaf24ac003fea9bff9837d1eedb6088758d41e100c1552930151f677739"},
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.3.6"
+requires_python = ">=3.8"
+summary = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
+groups = ["lint"]
+files = [
+    {file = "platformdirs-4.3.6-py3-none-any.whl", hash = "sha256:73e575e1408ab8103900836b97580d5307456908a03e92031bab39e4554cc3fb"},
+    {file = "platformdirs-4.3.6.tar.gz", hash = "sha256:357fb2acbc885b0419afd3ce3ed34564c13c9b95c89360cd9563f73aa5e2b907"},
 ]
 
 [[package]]
@@ -1551,7 +1616,7 @@ name = "tomli"
 version = "2.1.0"
 requires_python = ">=3.8"
 summary = "A lil' TOML parser"
-groups = ["test"]
+groups = ["lint", "test"]
 marker = "python_version < \"3.11\""
 files = [
     {file = "tomli-2.1.0-py3-none-any.whl", hash = "sha256:a5c57c3d1c56f5ccdf89f6523458f60ef716e210fc47c4cfb188c5ba473e0391"},
@@ -1577,7 +1642,7 @@ name = "typing-extensions"
 version = "4.12.2"
 requires_python = ">=3.8"
 summary = "Backported and Experimental Type Hints for Python 3.8+"
-groups = ["default"]
+groups = ["default", "lint"]
 files = [
     {file = "typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d"},
     {file = "typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,3 +37,8 @@ build-backend = "pdm.backend"
 
 [tool.pdm]
 distribution = true
+
+[dependency-groups]
+test = [
+    "pytest>=8.3.3",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,3 +42,6 @@ distribution = true
 test = [
     "pytest>=8.3.3",
 ]
+lint = [
+    "black>=24.10.0",
+]

--- a/src/observers/stores/base.py
+++ b/src/observers/stores/base.py
@@ -1,7 +1,9 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
-from observers.observers.base import Record
+if TYPE_CHECKING:
+    from observers.observers.base import Record
 
 
 @dataclass
@@ -11,7 +13,7 @@ class Store(ABC):
     """
 
     @abstractmethod
-    def add(self, record: Record):
+    def add(self, record: "Record"):
         """Add a new record to the store"""
         pass
 

--- a/src/observers/stores/datasets.py
+++ b/src/observers/stores/datasets.py
@@ -40,12 +40,12 @@ class DatasetsStore(Store):
         except Exception:
             login()
 
-        self._temp_dir = tempfile.mkdtemp(prefix="observers_dataset_")
-
         if self.folder_path is None:
+            self._temp_dir = tempfile.mkdtemp(prefix="observers_dataset_")
             self.folder_path = self._temp_dir
-
-        atexit.register(self._cleanup)
+            atexit.register(self._cleanup)
+        else:
+            os.makedirs(self.folder_path, exist_ok=True)
 
     def _cleanup(self):
         """Clean up temporary directory on exit"""

--- a/src/observers/stores/datasets.py
+++ b/src/observers/stores/datasets.py
@@ -51,6 +51,7 @@ class DatasetsStore(Store):
         """Clean up temporary directory on exit"""
         if self._temp_dir and os.path.exists(self._temp_dir):
             import shutil
+
             shutil.rmtree(self._temp_dir)
 
     def _init_table(self, record: "Record"):

--- a/tests/test_dataset_store.py
+++ b/tests/test_dataset_store.py
@@ -44,10 +44,16 @@ def test_folder_path_defaults_to_temp_dir(datasets_store):
     assert datasets_store.folder_path == datasets_store._temp_dir
 
 
-def test_custom_folder_path(mock_whoami, mock_login):
-    """Test that custom folder_path is respected"""
-    custom_path = "/custom/path"
+def test_custom_folder_path(mock_whoami, mock_login, tmp_path):
+    """Test that custom folder_path is respected and not deleted during cleanup"""
+    custom_path = str(tmp_path / "custom_datasets")
+    os.makedirs(custom_path, exist_ok=True)
+
     store = DatasetsStore(folder_path=custom_path)
     assert store.folder_path == custom_path
-    assert store._temp_dir != custom_path
+    assert store._temp_dir is None
+
     store._cleanup()
+    assert os.path.exists(
+        custom_path
+    ), "Custom folder should not be deleted during cleanup"

--- a/tests/test_dataset_store.py
+++ b/tests/test_dataset_store.py
@@ -1,0 +1,46 @@
+import os
+import pytest
+from unittest.mock import patch
+from observers.stores.datasets import DatasetsStore
+
+@pytest.fixture
+def mock_whoami():
+    with patch('observers.stores.datasets.whoami') as mock:
+        mock.return_value = {}
+        yield mock
+
+@pytest.fixture
+def mock_login():
+    with patch('observers.stores.datasets.login') as mock:
+        yield mock
+
+@pytest.fixture
+def datasets_store(mock_whoami, mock_login):
+    store = DatasetsStore()
+    yield store
+    store._cleanup()
+
+def test_temp_dir_creation(datasets_store):
+    """Test that temporary directory is created during initialization"""
+    assert datasets_store._temp_dir is not None
+    assert os.path.exists(datasets_store._temp_dir)
+
+def test_temp_dir_cleanup(mock_whoami, mock_login):
+    """Test that temporary directory is cleaned up properly"""
+    store = DatasetsStore()
+    temp_dir = store._temp_dir
+    assert os.path.exists(temp_dir)
+    
+    store._cleanup()
+    assert not os.path.exists(temp_dir)
+
+def test_folder_path_defaults_to_temp_dir(datasets_store):
+    """Test that folder_path defaults to temp_dir when not provided"""
+    assert datasets_store.folder_path == datasets_store._temp_dir
+
+def test_custom_folder_path():
+    """Test that custom folder_path is respected"""
+    custom_path = "/custom/path"
+    store = DatasetsStore(folder_path=custom_path)
+    assert store.folder_path == custom_path
+    assert store._temp_dir != custom_path

--- a/tests/test_dataset_store.py
+++ b/tests/test_dataset_store.py
@@ -3,16 +3,19 @@ import pytest
 from unittest.mock import patch
 from observers.stores.datasets import DatasetsStore
 
+
 @pytest.fixture
 def mock_whoami():
-    with patch('observers.stores.datasets.whoami') as mock:
+    with patch("observers.stores.datasets.whoami") as mock:
         mock.return_value = {}
         yield mock
 
+
 @pytest.fixture
 def mock_login():
-    with patch('observers.stores.datasets.login') as mock:
+    with patch("observers.stores.datasets.login") as mock:
         yield mock
+
 
 @pytest.fixture
 def datasets_store(mock_whoami, mock_login):
@@ -20,23 +23,27 @@ def datasets_store(mock_whoami, mock_login):
     yield store
     store._cleanup()
 
+
 def test_temp_dir_creation(datasets_store):
     """Test that temporary directory is created during initialization"""
     assert datasets_store._temp_dir is not None
     assert os.path.exists(datasets_store._temp_dir)
+
 
 def test_temp_dir_cleanup(mock_whoami, mock_login):
     """Test that temporary directory is cleaned up properly"""
     store = DatasetsStore()
     temp_dir = store._temp_dir
     assert os.path.exists(temp_dir)
-    
+
     store._cleanup()
     assert not os.path.exists(temp_dir)
+
 
 def test_folder_path_defaults_to_temp_dir(datasets_store):
     """Test that folder_path defaults to temp_dir when not provided"""
     assert datasets_store.folder_path == datasets_store._temp_dir
+
 
 def test_custom_folder_path():
     """Test that custom folder_path is respected"""

--- a/tests/test_dataset_store.py
+++ b/tests/test_dataset_store.py
@@ -30,13 +30,12 @@ def test_temp_dir_creation(datasets_store):
     assert os.path.exists(datasets_store._temp_dir)
 
 
-def test_temp_dir_cleanup(mock_whoami, mock_login):
+def test_temp_dir_cleanup(datasets_store):
     """Test that temporary directory is cleaned up properly"""
-    store = DatasetsStore()
-    temp_dir = store._temp_dir
+    temp_dir = datasets_store._temp_dir
     assert os.path.exists(temp_dir)
 
-    store._cleanup()
+    datasets_store._cleanup()
     assert not os.path.exists(temp_dir)
 
 
@@ -45,9 +44,10 @@ def test_folder_path_defaults_to_temp_dir(datasets_store):
     assert datasets_store.folder_path == datasets_store._temp_dir
 
 
-def test_custom_folder_path():
+def test_custom_folder_path(mock_whoami, mock_login):
     """Test that custom folder_path is respected"""
     custom_path = "/custom/path"
     store = DatasetsStore(folder_path=custom_path)
     assert store.folder_path == custom_path
     assert store._temp_dir != custom_path
+    store._cleanup()


### PR DESCRIPTION
The DatasetStore will use tmp directory by default unless a `folder_path` is specified. However, if `folder_path` is specified, it won't clean up that folder. Let me know if this is what we would expect.

- [x] Add Tests with Action
- [x] Add lint action 

this will close https://github.com/cfahlgren1/observers/issues/16