### PR TITLE
add option to pass custom question to argilla dataset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,6 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 /store
+.db.wal
+.wal
+.db

--- a/examples/stores/argilla_example.py
+++ b/examples/stores/argilla_example.py
@@ -1,3 +1,4 @@
+from argilla import TextQuestion  # noqa
 from observers.observers import wrap_openai
 from observers.stores import ArgillaStore
 from openai import OpenAI
@@ -5,7 +6,11 @@ from openai import OpenAI
 api_url = "<argilla-api-url>"
 api_key = "<argilla-api-key>"
 
-store = ArgillaStore(api_url=api_url, api_key=api_key)
+store = ArgillaStore(
+    api_url=api_url,
+    api_key=api_key,
+    # questions=[TextQuestion(name="text")], optional
+)
 
 openai_client = OpenAI()
 

--- a/src/observers/observers/models/docling.py
+++ b/src/observers/observers/models/docling.py
@@ -89,11 +89,11 @@ class DoclingRecord(Record):
             docling_object.caption_text
         ):
             data["text"] = docling_object.caption_text(document)
-        elif getattr(docling_object, "export_to_html") and callable(
+        elif hasattr(docling_object, "export_to_html") and callable(
             docling_object.export_to_html
         ):
             data["text"] = docling_object.export_to_html(document, add_caption=True)
-        elif getattr(docling_object, "export_to_document_tokens") and callable(
+        elif hasattr(docling_object, "export_to_document_tokens") and callable(
             docling_object.export_to_document_tokens
         ):
             export_to_document_tokens_params = inspect.signature(

--- a/src/observers/observers/models/openai.py
+++ b/src/observers/observers/models/openai.py
@@ -183,6 +183,10 @@ class OpenAIResponseRecord(Record):
     def image_fields(self):
         return []
 
+    @property
+    def text_fields(self):
+        return []
+
 
 def wrap_openai(
     client: "OpenAI",

--- a/src/observers/stores/argilla.py
+++ b/src/observers/stores/argilla.py
@@ -52,7 +52,7 @@ class ArgillaStore(Store):
 
     def _init_table(self, record: "Record") -> None:
         dataset_name = (
-            self.dataset_name or f"{record.table_name}_{str(uuid.uuid4())[:8]}"
+            self.dataset_name or f"{record.table_name}_{uuid.uuid4().hex[:8]}"
         )
         workspace_name = self.workspace_name or self._client.me.username
         workspace = self._client.workspaces(name=workspace_name)
@@ -70,9 +70,10 @@ class ArgillaStore(Store):
                 settings=settings,
                 client=self._client,
             ).create()
-        else:
-            if self.questions:
-                raise ValueError("Questions are not supported for existing datasets")
+        elif self.questions:
+            raise ValueError(
+                "Custom questions are not supported for existing datasets."
+            )
         self._dataset = dataset
         dataset_keys = (
             [field.name for field in dataset.settings.fields]

--- a/src/observers/stores/argilla.py
+++ b/src/observers/stores/argilla.py
@@ -105,5 +105,10 @@ class ArgillaStore(Store):
             self._init_table(record)
 
         record_dict = asdict(record)
+
+        for text_field in record.text_fields:
+            if text_field in record_dict:
+                record_dict[f"{text_field}_length"] = len(record_dict[text_field])
+
         record_dict = {k: v for k, v in record_dict.items() if k in self._dataset_keys}
         self._dataset.records.log([record_dict])

--- a/src/observers/stores/datasets.py
+++ b/src/observers/stores/datasets.py
@@ -93,8 +93,8 @@ class DatasetsStore(Store):
             shutil.rmtree(self._temp_dir)
 
     def _init_table(self, record: "Record"):
-        repo_name = self.repo_name or f"{record.table_name}_{str(uuid.uuid4())[:8]}"
-        org_name = self.org_name or whoami(token=self.token)["name"]
+        repo_name = self.repo_name or f"{record.table_name}_{uuid.uuid4().hex[:8]}"
+        org_name = self.org_name or whoami(token=self.token).get("name")
         repo_id = f"{org_name}/{repo_name}"
         self._filename = f"{record.table_name}_{uuid.uuid4()}.json"
         self._scheduler = CommitScheduler(

--- a/src/observers/stores/datasets.py
+++ b/src/observers/stores/datasets.py
@@ -93,7 +93,7 @@ class DatasetsStore(Store):
             shutil.rmtree(self._temp_dir)
 
     def _init_table(self, record: "Record"):
-        repo_name = self.repo_name or "my-dataset"
+        repo_name = self.repo_name or f"{record.table_name}_{str(uuid.uuid4())[:8]}"
         org_name = self.org_name or whoami(token=self.token)["name"]
         repo_id = f"{org_name}/{repo_name}"
         self._filename = f"{record.table_name}_{uuid.uuid4()}.json"

--- a/src/observers/stores/datasets.py
+++ b/src/observers/stores/datasets.py
@@ -33,7 +33,8 @@ def push_to_hub(self):
         for record in records:
             if record.get("image") and record["image"].get("path"):
                 image_path = Path(self.folder_path) / record["image"]["path"]
-                record["image"] = Image.open(image_path)
+                with Image.open(image_path) as img:
+                    record["image"] = img.copy()
             data.append(record)
 
         dataset = Dataset.from_list(data)

--- a/src/observers/stores/duckdb.py
+++ b/src/observers/stores/duckdb.py
@@ -52,15 +52,10 @@ class DuckDBStore(Store):
 
     def add(self, record: "Record"):
         """Add a new record to the database"""
-        table_exists = False
-        table_name = None
-        if self._tables:
-            for table in self._tables:
-                if record.table_name in table:
-                    table_exists = True
-                    table_name = table
-                    break
-        if not table_exists:
+        table_name = next(
+            (table for table in self._tables if record.table_name in table), None
+        )
+        if not table_name:
             table_name = self._init_table(record)
 
         record_dict = asdict(record)

--- a/src/observers/stores/duckdb.py
+++ b/src/observers/stores/duckdb.py
@@ -40,7 +40,7 @@ class DuckDBStore(Store):
         return cls(path=path)
 
     def _init_table(self, record: "Record") -> str:
-        table_name = f"{record.table_name}_{str(uuid.uuid4())[:8]}"
+        table_name = f"{record.table_name}_{uuid.uuid4().hex[:8]}"
         duckdb_schema = record.duckdb_schema.replace(record.table_name, table_name)
         self._conn.execute(duckdb_schema)
         self._tables.append(table_name)

--- a/src/observers/stores/duckdb.py
+++ b/src/observers/stores/duckdb.py
@@ -39,11 +39,12 @@ class DuckDBStore(Store):
             path = os.path.join(os.getcwd(), DEFAULT_DB_NAME)
         return cls(path=path)
 
-    def _init_table(self, record: "Record"):
+    def _init_table(self, record: "Record") -> str:
         table_name = f"{record.table_name}_{str(uuid.uuid4())[:8]}"
         duckdb_schema = record.duckdb_schema.replace(record.table_name, table_name)
         self._conn.execute(duckdb_schema)
         self._tables.append(table_name)
+        return table_name
 
     def _get_tables(self) -> List[str]:
         """Get all tables in the database"""


### PR DESCRIPTION
- allow to pass custom non-opinionated configuration for questions to argilla
- creates tables per sesssion based on `f"{table_name}_{str(uuid.uuid4())[:8]}"` when no explicit name is provided. https://huggingface.co/datasets/davidberenstein1957/openai_records_a5d2a9e1. @cfahlgren1 WDYT of this approach? I am not sure if we also want to enforce this for duckdb though.

```python
from argilla import TextQuestion 
from observers.observers import wrap_openai
from observers.stores import ArgillaStore
from openai import OpenAI

api_url = "<argilla-api-url>"
api_key = "<argilla-api-key>"

store = ArgillaStore(
    api_url=api_url,
    api_key=api_key,
    questions=[TextQuestion(name="text")], # instead of our generic config
)

openai_client = OpenAI()

client = wrap_openai(openai_client, store=store)

response = client.chat.completions.create(
    model="gpt-4o",
    messages=[{"role": "user", "content": "Tell me a joke."}],
)

print(response.choices[0].message.content)
```