### PR TITLE
Add logging rate parameter to API wrappers

### DIFF
--- a/src/observers/models/aisuite.py
+++ b/src/observers/models/aisuite.py
@@ -35,4 +35,5 @@ def wrap_aisuite(
         store=store,
         tags=tags,
         properties=properties,
+        logging_rate=logging_rate,
     )

--- a/src/observers/models/aisuite.py
+++ b/src/observers/models/aisuite.py
@@ -16,6 +16,7 @@ def wrap_aisuite(
     store: Optional[Union["DatasetsStore", DuckDBStore, "ArgillaStore"]] = None,
     tags: Optional[List[str]] = None,
     properties: Optional[Dict[str, Any]] = None,
+    logging_rate: Optional[float] = 1,
 ) -> "Client":
     """Wraps Aisuite client to track API calls in a Store.
 
@@ -24,6 +25,7 @@ def wrap_aisuite(
         store: Store for persistence (creates new if None)
         tags: Optional tags to associate with records
         properties: Optional properties to associate with records
+        logging_rate: Optional logging rate to use for logging, defaults to 1
     """
     return ChatCompletionObserver(
         client=client,

--- a/src/observers/models/base.py
+++ b/src/observers/models/base.py
@@ -1,4 +1,5 @@
 import datetime
+import random
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
@@ -6,7 +7,6 @@ from typing_extensions import Self
 
 from observers.base import Message, Record
 from observers.stores.datasets import DatasetsStore
-
 
 if TYPE_CHECKING:
     from argilla import Argilla
@@ -189,6 +189,8 @@ class ChatCompletionObserver:
             The tags to associate with records.
         properties (`Dict[str, Any]`, *optional*):
             The properties to associate with records.
+        logging_rate (`float`, *optional*):
+            The logging rate to use for logging, defaults to 1
     """
 
     def __init__(
@@ -200,6 +202,7 @@ class ChatCompletionObserver:
         store: Optional[Union["DuckDBStore", DatasetsStore]] = None,
         tags: Optional[List[str]] = None,
         properties: Optional[Dict[str, Any]] = None,
+        logging_rate: Optional[float] = 1,
         **kwargs: Any,
     ):
         self.client = client
@@ -210,6 +213,7 @@ class ChatCompletionObserver:
         self.tags = tags or []
         self.properties = properties or {}
         self.kwargs = kwargs
+        self.logging_rate = logging_rate
 
     @property
     def chat(self) -> Self:
@@ -246,8 +250,9 @@ class ChatCompletionObserver:
                 tags=self.tags,
                 properties=self.properties,
             )
+            if random.random() < self.logging_rate:
+                self.store.add(record)
 
-            self.store.add(record)
             return response
 
         except Exception as e:
@@ -348,8 +353,8 @@ class AsyncChatCompletionObserver(ChatCompletionObserver):
                 tags=self.tags,
                 properties=self.properties,
             )
-
-            await self.store.add_async(record)
+            if random.random() < self.logging_rate:
+                await self.store.add_async(record)
             return response
 
         except Exception as e:

--- a/src/observers/models/docling.py
+++ b/src/observers/models/docling.py
@@ -320,6 +320,7 @@ def wrap_docling(
                     page=page,
                     tags=tags,
                     properties=properties,
+                    logging_rate=logging_rate,
                 )
                 store.add(record)
             if isinstance(docling_object, PictureItem) and "pictures" in media_types:
@@ -329,6 +330,7 @@ def wrap_docling(
                     page=page,
                     tags=tags,
                     properties=properties,
+                    logging_rate=logging_rate,
                 )
                 store.add(record)
             if isinstance(docling_object, TableItem) and "tables" in media_types:
@@ -338,6 +340,7 @@ def wrap_docling(
                     page=page,
                     tags=tags,
                     properties=properties,
+                    logging_rate=logging_rate,
                 )
                 store.add(record)
 

--- a/src/observers/models/docling.py
+++ b/src/observers/models/docling.py
@@ -269,6 +269,7 @@ def wrap_docling(
     tags: Optional[List[str]] = None,
     properties: Optional[Dict[str, Any]] = None,
     media_types: Optional[List[str]] = None,
+    logging_rate: Optional[float] = 1,
 ) -> "DocumentConverter":
     """
     Wrap DocumentConverter client to track API calls in a Store.
@@ -279,6 +280,7 @@ def wrap_docling(
         tags: Optional list of tags to associate with records
         properties: Optional dictionary of properties to associate with records
         media_type: Optional media type to associate with records "texts", "pictures", "tables" or None for all
+        logging_rate: Optional logging rate to use for logging, defaults to 1
 
     Returns:
         DocumentConverter: Wrapped DocumentConverter client

--- a/src/observers/models/docling.py
+++ b/src/observers/models/docling.py
@@ -1,4 +1,5 @@
 import base64
+import random
 from dataclasses import dataclass
 from io import BytesIO
 from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Union
@@ -310,6 +311,11 @@ def wrap_docling(
 
     def process_document(document, page_no, page) -> None:
         for docling_object, _level in document.iterate_items(page_no=page_no):
+            if random.random() < logging_rate:
+                SHOULD_LOG = True
+            else:
+                SHOULD_LOG = False
+
             if (
                 isinstance(docling_object, (SectionHeaderItem, ListItem, TextItem))
                 and "texts" in media_types
@@ -320,9 +326,9 @@ def wrap_docling(
                     page=page,
                     tags=tags,
                     properties=properties,
-                    logging_rate=logging_rate,
                 )
-                store.add(record)
+                if SHOULD_LOG:
+                    store.add(record)
             if isinstance(docling_object, PictureItem) and "pictures" in media_types:
                 record = DoclingRecord.create(
                     docling_object=docling_object,
@@ -330,9 +336,9 @@ def wrap_docling(
                     page=page,
                     tags=tags,
                     properties=properties,
-                    logging_rate=logging_rate,
                 )
-                store.add(record)
+                if SHOULD_LOG:
+                    store.add(record)
             if isinstance(docling_object, TableItem) and "tables" in media_types:
                 record = DoclingRecord.create(
                     docling_object=docling_object,
@@ -340,9 +346,9 @@ def wrap_docling(
                     page=page,
                     tags=tags,
                     properties=properties,
-                    logging_rate=logging_rate,
                 )
-                store.add(record)
+                if SHOULD_LOG:
+                    store.add(record)
 
     def convert(*args, **kwargs) -> "DoclingDocument":
         result = original_convert(*args, **kwargs)

--- a/src/observers/models/hf_client.py
+++ b/src/observers/models/hf_client.py
@@ -2,16 +2,15 @@ import uuid
 from dataclasses import asdict
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
+from huggingface_hub import AsyncInferenceClient, InferenceClient
 from typing_extensions import Self
 
-from huggingface_hub import AsyncInferenceClient, InferenceClient
 from observers.models.base import (
     AsyncChatCompletionObserver,
     ChatCompletionObserver,
     ChatCompletionRecord,
 )
 from observers.stores.datasets import DatasetsStore
-
 
 if TYPE_CHECKING:
     from observers.stores.duckdb import DuckDBStore
@@ -49,6 +48,7 @@ def wrap_hf_client(
     store: Optional[Union["DuckDBStore", DatasetsStore]] = None,
     tags: Optional[List[str]] = None,
     properties: Optional[Dict[str, Any]] = None,
+    logging_rate: Optional[float] = 1,
 ) -> Union[AsyncChatCompletionObserver, ChatCompletionObserver]:
     """
     Wraps Hugging Face's Inference Client in an observer.
@@ -62,6 +62,8 @@ def wrap_hf_client(
             The tags to associate with records.
         properties (`Dict[str, Any]`, *optional*):
             The properties to associate with records.
+        logging_rate (`float`, *optional*):
+            The logging rate to use for logging, defaults to 1
     """
     if isinstance(client, AsyncInferenceClient):
         return AsyncChatCompletionObserver(

--- a/src/observers/models/hf_client.py
+++ b/src/observers/models/hf_client.py
@@ -74,6 +74,7 @@ def wrap_hf_client(
             store=store,
             tags=tags,
             properties=properties,
+            logging_rate=logging_rate,
         )
 
     return ChatCompletionObserver(
@@ -84,4 +85,5 @@ def wrap_hf_client(
         store=store,
         tags=tags,
         properties=properties,
+        logging_rate=logging_rate,
     )

--- a/src/observers/models/litellm.py
+++ b/src/observers/models/litellm.py
@@ -37,6 +37,7 @@ def wrap_litellm(
             store=store,
             tags=tags,
             properties=properties,
+            logging_rate=logging_rate,
         )
 
     return ChatCompletionObserver(
@@ -47,4 +48,5 @@ def wrap_litellm(
         store=store,
         tags=tags,
         properties=properties,
+        logging_rate=logging_rate,
     )

--- a/src/observers/models/litellm.py
+++ b/src/observers/models/litellm.py
@@ -16,6 +16,7 @@ def wrap_litellm(
     store: Optional[Union["DatasetsStore", "DuckDBStore", "ArgillaStore"]] = None,
     tags: Optional[List[str]] = None,
     properties: Optional[Dict[str, Any]] = None,
+    logging_rate: Optional[float] = 1,
 ) -> Union[AsyncChatCompletionObserver, ChatCompletionObserver]:
     """
     Wrap Litellm completion function to track API calls in a Store.
@@ -25,6 +26,7 @@ def wrap_litellm(
         store: Store instance for persistence. Creates new if None
         tags: Optional list of tags to associate with records
         properties: Optional dictionary of properties to associate with records
+        logging_rate: Optional logging rate to use for logging, defaults to 1
     """
     if client.__name__ == "acompletion":
         return AsyncChatCompletionObserver(

--- a/src/observers/models/openai.py
+++ b/src/observers/models/openai.py
@@ -13,7 +13,6 @@ from observers.models.base import (
 )
 from observers.stores.datasets import DatasetsStore
 
-
 if TYPE_CHECKING:
     from observers.stores.duckdb import DuckDBStore
 
@@ -64,6 +63,8 @@ def wrap_openai(
             The tags to associate with records.
         properties (`Dict[str, Any]`, *optional*):
             The properties to associate with records.
+        logging_rate (`float`, *optional*):
+            The logging rate to use for logging, defaults to 1
     """
     if isinstance(client, AsyncOpenAI):
         return AsyncChatCompletionObserver(
@@ -74,6 +75,7 @@ def wrap_openai(
             store=store,
             tags=tags,
             properties=properties,
+            logging_rate=logging_rate,
         )
 
     return ChatCompletionObserver(
@@ -84,4 +86,5 @@ def wrap_openai(
         store=store,
         tags=tags,
         properties=properties,
+        logging_rate=logging_rate,
     )

--- a/src/observers/models/openai.py
+++ b/src/observers/models/openai.py
@@ -50,6 +50,7 @@ def wrap_openai(
     store: Optional[Union["DuckDBStore", DatasetsStore]] = None,
     tags: Optional[List[str]] = None,
     properties: Optional[Dict[str, Any]] = None,
+    logging_rate: Optional[float] = 1,
 ) -> Union[ChatCompletionObserver, AsyncChatCompletionObserver]:
     """
     Wraps an OpenAI client in an observer.

--- a/src/observers/models/transformers.py
+++ b/src/observers/models/transformers.py
@@ -1,9 +1,9 @@
 import uuid
 from typing import Any, Dict, List, Optional, Union
 
+import transformers
 from typing_extensions import Self
 
-import transformers
 from observers.models.base import ChatCompletionObserver, ChatCompletionRecord
 from observers.stores.datasets import DatasetsStore
 from observers.stores.duckdb import DuckDBStore
@@ -40,6 +40,7 @@ def wrap_transformers(
     store: Optional[Union[DuckDBStore, DatasetsStore]] = None,
     tags: Optional[List[str]] = None,
     properties: Optional[Dict[str, Any]] = None,
+    logging_rate: Optional[float] = 1,
 ) -> ChatCompletionObserver:
     """
     Wraps a transformers client in an observer.
@@ -53,6 +54,8 @@ def wrap_transformers(
             The tags to associate with records.
         properties (`Dict[str, Any]`, *optional*):
             The properties to associate with records.
+        logging_rate (`float`, *optional*):
+            The logging rate to use for logging, defaults to 1
 
     Returns:
         `ChatCompletionObserver`:
@@ -66,4 +69,5 @@ def wrap_transformers(
         store=store,
         tags=tags,
         properties=properties,
+        logging_rate=logging_rate,
     )


### PR DESCRIPTION
This commit introduces an optional `logging_rate` parameter to various API wrapper functions, allowing users to control the frequency of logging actions. The default value is set to 1, ensuring that logging occurs for every call unless specified otherwise. The changes were made in the following files: `aisuite.py`, `base.py`, `docling.py`, `hf_client.py`, `litellm.py`, `openai.py`, and `transformers.py`.